### PR TITLE
GetRealmInfoByID() returns real alias realm if a virtual nameless realm ID is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ﻿LibRealmInfo
 ===============
 
-Library to provide information about realms.
+> **IMPORTANT:** LibRealmInfo is now maintained here: <https://github.com/janekjl/LibRealmInfo>. This original repository is now archived, and the original author (Phanx) is no longer involved in the library's development or maintenance.
+
+World of Warcraft addon library to provide information about realms.
 
 * [Download on CurseForge](https://wow.curseforge.com/projects/librealminfo)
 * [Download on WoWInterface](https://www.wowinterface.com/downloads/info22987-LibRealmInfo.html)


### PR DESCRIPTION
Some realms are connected into a "virtual" realm that has an ID but no name.
When attempting to fetch the realm data by providing such realm ID to `GetRealmInfoByID()` we get no result.

This pull requests implements an "alias" mechanism for `GetRealmInfoByID()` that returns the data of the linked realm having the smallest ID instead of no result.

## How to test
Test on a character created on US-Anvilmar
`/dump LibStub("LibRealmInfo"):GetRealmInfoByUnit("player") -- Anvilmar with ID 1288`
`/dump LibStub("LibRealmInfo"):GetRealmInfoByID(1174) -- Anvilmar with ID 1288`
`/dump LibStub("LibRealmInfo"):GetRealmInfoByID(1288) -- Anvilmar with ID 1288`
`/dump LibStub("LibRealmInfo"):GetRealmInfoByID(1294) -- Undermine with ID 1294`
`/dump LibStub("LibRealmInfo"):GetRealmInfoByID(123456) -- Empty result`

